### PR TITLE
Chweez/updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	res, err := svc.STKPushSimulation(mpesa.STKPush{
+	res, err := svc.Simulation(mpesa.Express{
 		BusinessShortCode: "",
 		Password:          "",
 		Timestamp:         "",

--- a/api.go
+++ b/api.go
@@ -36,7 +36,7 @@ func New(appKey, appSecret string, env int) (Service, error) {
 }
 
 //Generate Mpesa Daraja Access Token
-func (s Service) authenticate() (string, error) {
+func (s Service) auth() (string, error) {
 	b := []byte(s.AppKey + ":" + s.AppSecret)
 	encoded := base64.StdEncoding.EncodeToString(b)
 
@@ -67,13 +67,13 @@ func (s Service) authenticate() (string, error) {
 	return accessToken, nil
 }
 
-// STKPushSimulation sends an STK push?
-func (s Service) MPESAExpressSimulation(mpesaExpress MPESAExpress) (string, error) {
-	body, err := json.Marshal(mpesaExpress)
+// Simulation requests user device for payment
+func (s Service) Simulation(express Express) (string, error) {
+	body, err := json.Marshal(express)
 	if err != nil {
 		return "", nil
 	}
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -84,17 +84,17 @@ func (s Service) MPESAExpressSimulation(mpesaExpress MPESAExpress) (string, erro
 	headers["cache-control"] = "no-cache"
 
 	url := s.baseURL() + "mpesa/stkpush/v1/processrequest"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
-// STKPushTransactionStatus gets a status
-func (s Service) MPESAExpressTransactionStatus(mpesaExpress MPESAExpress) (string, error) {
-	body, err := json.Marshal(mpesaExpress)
+// TransactionStatus gets status of a transaction
+func (s Service) TransactionStatus(express Express) (string, error) {
+	body, err := json.Marshal(express)
 	if err != nil {
 		return "", nil
 	}
 
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -104,17 +104,17 @@ func (s Service) MPESAExpressTransactionStatus(mpesaExpress MPESAExpress) (strin
 	headers["Authorization"] = "Bearer " + auth
 
 	url := s.baseURL() + "mpesa/stkpushquery/v1/query"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // C2BRegisterURL requests
-func (s Service) C2BRegisterURL(c2BRegisterURL C2BRegisterURL) (string, error) {
-	body, err := json.Marshal(c2BRegisterURL)
+func (s Service) C2BRegisterURL(c2bRegisterURL C2BRegisterURL) (string, error) {
+	body, err := json.Marshal(c2bRegisterURL)
 	if err != nil {
 		return "", err
 	}
 
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -125,7 +125,7 @@ func (s Service) C2BRegisterURL(c2BRegisterURL C2BRegisterURL) (string, error) {
 	headers["Cache-Control"] = "no-cache"
 
 	url := s.baseURL() + "mpesa/c2b/v1/registerurl"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // C2BSimulation sends a new request
@@ -135,7 +135,7 @@ func (s Service) C2BSimulation(c2b C2B) (string, error) {
 		return "", err
 	}
 
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -146,7 +146,7 @@ func (s Service) C2BSimulation(c2b C2B) (string, error) {
 	headers["cache-control"] = "no-cache"
 
 	url := s.baseURL() + "mpesa/c2b/v1/simulate"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // B2CRequest sends a new request
@@ -156,7 +156,7 @@ func (s Service) B2CRequest(b2c B2C) (string, error) {
 		return "", err
 	}
 
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -167,7 +167,7 @@ func (s Service) B2CRequest(b2c B2C) (string, error) {
 	headers["cache-control"] = "no-cache"
 
 	url := s.baseURL() + "mpesa/b2c/v1/paymentrequest"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // B2BRequest sends a new request
@@ -176,7 +176,7 @@ func (s Service) B2BRequest(b2b B2B) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -187,7 +187,7 @@ func (s Service) B2BRequest(b2b B2B) (string, error) {
 	headers["cache-control"] = "no-cache"
 
 	url := s.baseURL() + "mpesa/b2b/v1/paymentrequest"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // Reversal requests a reversal?
@@ -197,7 +197,7 @@ func (s Service) Reversal(reversal Reversal) (string, error) {
 		return "", err
 	}
 
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -208,12 +208,12 @@ func (s Service) Reversal(reversal Reversal) (string, error) {
 	headers["cache-control"] = "no-cache"
 
 	url := s.baseURL() + "safaricom/reversal/v1/request" //TODO :: CONFIRM THIS URL/ENDPOINT???
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
 // BalanceInquiry sends a balance inquiry
 func (s Service) BalanceInquiry(balanceInquiry BalanceInquiry) (string, error) {
-	auth, err := s.authenticate()
+	auth, err := s.auth()
 	if err != nil {
 		return "", nil
 	}
@@ -230,10 +230,10 @@ func (s Service) BalanceInquiry(balanceInquiry BalanceInquiry) (string, error) {
 	headers["postman-token"] = "2aa448be-7d56-a796-065f-b378ede8b136"
 
 	url := s.baseURL() + "mpesa/accountbalance/v1/query"
-	return s.newStringRequest(url, body, headers)
+	return s.newReq(url, body, headers)
 }
 
-func (s Service) newStringRequest(url string, body []byte, headers map[string]string) (string, error) {
+func (s Service) newReq(url string, body []byte, headers map[string]string) (string, error) {
 	request, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return "", nil

--- a/model.go
+++ b/model.go
@@ -43,8 +43,8 @@ type B2B struct {
 	ResultURL              string
 }
 
-// STKPush is a model
-type MPESAExpress struct {
+// Express is a model
+type Express struct {
 	BusinessShortCode string
 	Password          string
 	Timestamp         string


### PR DESCRIPTION
Code clean-up and readme update.

I also did some changes;
- Since the package is called `mpesa`, there is no need in calling something `MPESAExpress` as it will be called in user code `mpesa.MPESAExpress`. I believe `mpesa.Express` is more concise. 
- Same thing for `mpesa.MPESAExpressSimulation`, I believe `mpesa.Simulation(express)` is more consice, `express` being an `mpesa.Express` struct.
- I did a few package private name changes to reduce the funcs name length. It smelled like java.