### PR TITLE
Enhancements utils

### DIFF
--- a/model.go
+++ b/model.go
@@ -1,5 +1,9 @@
 package mpesa
 
+import (
+	"time"
+)
+
 type authResponse struct {
 	AccessToken string `json:"access_token"`
 }
@@ -56,6 +60,28 @@ type Express struct {
 	CallBackURL       string
 	AccountReference  string
 	TransactionDesc   string
+}
+
+var defaultTransactionType = "CustomerPayBillOnline"
+
+// NewExpress creates an express request object. Does the password generation and timestamp
+func NewExpress(shortCode, amount, phoneNumber, callbackURL, ref, desc, passkey string) *Express {
+	timestamp := time.Now().Format("20060102030405")
+	password := GeneratePassword(shortCode, passkey, timestamp)
+
+	return &Express{
+		BusinessShortCode: shortCode,
+		Password:          password,
+		Timestamp:         timestamp,
+		TransactionType:   defaultTransactionType,
+		Amount:            amount,
+		PartyA:            phoneNumber,
+		PartyB:            shortCode,
+		PhoneNumber:       phoneNumber,
+		CallBackURL:       callbackURL,
+		AccountReference:  ref,
+		TransactionDesc:   desc,
+	}
 }
 
 // Reversal is a model

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,12 @@
+package mpesa
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// GeneratePassword by base64 encoding BusinessShortcode, Passkey, and Timestamp
+func GeneratePassword(shortCode, passkey, timestamp string) string {
+	str := fmt.Sprintf("%s%s%s", shortCode, passkey, timestamp)
+	return base64.StdEncoding.EncodeToString([]byte(str))
+}


### PR DESCRIPTION
I've added two convenient  utility methods that would remove some extra steps when generating an STK push.

* `GeneratePassword` method required when you want to generate the password required field for an STK Push
* `NewExpress` some of the fields point to the same value, and one, `TransactionType` is a single default. Makes use of `GeneratePassword`.